### PR TITLE
Adjust BaseTestCase inheritance and update handlers

### DIFF
--- a/Models/BaseTestCase.cs
+++ b/Models/BaseTestCase.cs
@@ -5,7 +5,7 @@ namespace SQLUnitTest.Models
     public class BaseTestCase
     {
         public string StoredProcedure { get; set; } = string.Empty;
-        public IDictionary<string, object> Parameters { get; set; } = new Dictionary<string, object>();
+        public Dictionary<string, object> Parameters { get; set; } = new Dictionary<string, object>();
         public string? Connection { get; set; }
         public string TestName { get; set; } = string.Empty;
         public string Type { get; set; } = string.Empty;

--- a/Models/BaseTestCase.cs
+++ b/Models/BaseTestCase.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace SQLUnitTest.Models
+{
+    public class BaseTestCase
+    {
+        public string StoredProcedure { get; set; } = string.Empty;
+        public Dictionary<string, object> Parameters { get; set; } = new();
+        public string? Connection { get; set; }
+        public string TestName { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
+    }
+}

--- a/Models/BaseTestCase.cs
+++ b/Models/BaseTestCase.cs
@@ -5,7 +5,7 @@ namespace SQLUnitTest.Models
     public class BaseTestCase
     {
         public string StoredProcedure { get; set; } = string.Empty;
-        public Dictionary<string, object> Parameters { get; set; } = new();
+        public IDictionary<string, object> Parameters { get; set; } = new Dictionary<string, object>();
         public string? Connection { get; set; }
         public string TestName { get; set; } = string.Empty;
         public string Type { get; set; } = string.Empty;

--- a/Models/ExecutionTestCase.cs
+++ b/Models/ExecutionTestCase.cs
@@ -3,10 +3,7 @@ namespace SQLUnitTest.Models
     /// <summary>
     /// Executes a stored procedure and validates that it runs successfully.
     /// </summary>
-    public class ExecutionTestCase : TestCase
+    public class ExecutionTestCase : BaseTestCase
     {
-        public string StoredProcedure { get; set; } = string.Empty;
-        public object? Parameters { get; set; }
-        public string? Connection { get; set; }
     }
 }

--- a/Models/OutputParameterTestCase.cs
+++ b/Models/OutputParameterTestCase.cs
@@ -5,11 +5,8 @@ namespace SQLUnitTest.Models
     /// <summary>
     /// Validates output parameters of a stored procedure.
     /// </summary>
-    public class OutputParameterTestCase : TestCase
+    public class OutputParameterTestCase : BaseTestCase
     {
-        public string StoredProcedure { get; set; } = string.Empty;
-        public object? Parameters { get; set; }
         public IDictionary<string, object>? Expected { get; set; }
-        public string? Connection { get; set; }
     }
 }

--- a/Models/StoredProcedureCompareTestCase.cs
+++ b/Models/StoredProcedureCompareTestCase.cs
@@ -3,13 +3,10 @@ namespace SQLUnitTest.Models
     /// <summary>
     /// Compares the results of two stored procedures.
     /// </summary>
-    public class StoredProcedureCompareTestCase : TestCase
+    public class StoredProcedureCompareTestCase : BaseTestCase
     {
-        public string StoredProcedure { get; set; } = string.Empty;
-        public object? Parameters { get; set; }
         public string ExpectedStoredProcedure { get; set; } = string.Empty;
         public object? ExpectedParameters { get; set; }
-        public string? Connection { get; set; }
         public string? ExpectedConnection { get; set; }
         public string[]? ExcludeColumns { get; set; }
     }

--- a/Models/TestCase.cs
+++ b/Models/TestCase.cs
@@ -4,9 +4,9 @@ using SQLUnitTest.Models.Mocking;
 namespace SQLUnitTest.Models
 {
     /// <summary>
-    /// Base class for all test cases.
+    /// Base class for test case containers.
     /// </summary>
-    public abstract class TestCase
+    public class TestCase
     {
         /// <summary>
         /// Optional description of the test.
@@ -26,6 +26,6 @@ namespace SQLUnitTest.Models
         /// <summary>
         /// Collection of nested test cases that describe expectations.
         /// </summary>
-        public IList<TestCase>? Should { get; set; }
+        public IList<BaseTestCase>? Should { get; set; }
     }
 }

--- a/Models/TestCase.cs
+++ b/Models/TestCase.cs
@@ -25,7 +25,8 @@ namespace SQLUnitTest.Models
 
         /// <summary>
         /// Collection of nested test cases that describe expectations.
+        /// Initialized to an empty list so callers don't need null checks.
         /// </summary>
-        public IList<BaseTestCase>? Should { get; set; }
+        public IList<BaseTestCase> Should { get; set; } = new List<BaseTestCase>();
     }
 }

--- a/Reporting/MarkdownReporter.cs
+++ b/Reporting/MarkdownReporter.cs
@@ -12,7 +12,10 @@ namespace SQLUnitTest.Reporting
         public string CreateExecutionReport(ExecutionTestCase test, DataSet result)
         {
             var sb = new StringBuilder();
-            sb.AppendLine($"# Feature: {test.Description ?? test.StoredProcedure}");
+            var title = string.IsNullOrWhiteSpace(test.TestName)
+                ? test.StoredProcedure
+                : test.TestName;
+            sb.AppendLine($"# Feature: {title}");
             sb.AppendLine();
             sb.AppendLine("Execution succeeded with " + result.Tables.Count + " result set(s).");
             return sb.ToString();

--- a/Repositories/AdoDbRepository.cs
+++ b/Repositories/AdoDbRepository.cs
@@ -60,6 +60,10 @@ namespace SQLUnitTest.Repositories
             {
                 SqlDbType = GetSqlDbType(value)
             };
+            if (param.SqlDbType == SqlDbType.NVarChar)
+            {
+                param.Size = -1; // use NVARCHAR(MAX) by default
+            }
             cmd.Parameters.Add(param);
         }
 

--- a/Repositories/AdoDbRepository.cs
+++ b/Repositories/AdoDbRepository.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Threading.Tasks;
+using System.Numerics;
 
 namespace SQLUnitTest.Repositories
 {
@@ -60,10 +61,28 @@ namespace SQLUnitTest.Repositories
             {
                 SqlDbType = GetSqlDbType(value)
             };
+
             if (param.SqlDbType == SqlDbType.NVarChar)
             {
                 param.Size = -1; // use NVARCHAR(MAX) by default
             }
+            else if (param.SqlDbType == SqlDbType.Decimal && value != null)
+            {
+                decimal dec = Convert.ToDecimal(value);
+                int[] bits = decimal.GetBits(dec);
+                byte scale = (byte)((bits[3] >> 16) & 0x7F);
+                BigInteger intValue = (new BigInteger((uint)bits[2]) << 64) |
+                                      (new BigInteger((uint)bits[1]) << 32) |
+                                      (uint)bits[0];
+                byte precision = (byte)(intValue.ToString().TrimStart('0').Length);
+                if (precision == 0)
+                {
+                    precision = 1;
+                }
+                param.Precision = precision;
+                param.Scale = scale;
+            }
+
             cmd.Parameters.Add(param);
         }
 

--- a/Repositories/AdoDbRepository.cs
+++ b/Repositories/AdoDbRepository.cs
@@ -27,14 +27,14 @@ namespace SQLUnitTest.Repositories
             {
                 foreach (var kvp in dict)
                 {
-                    cmd.Parameters.AddWithValue($"@{kvp.Key}", kvp.Value ?? DBNull.Value);
+                    AddParameter(cmd, kvp.Key, kvp.Value);
                 }
             }
             else if (parameters != null)
             {
                 foreach (var prop in parameters.GetType().GetProperties())
                 {
-                    cmd.Parameters.AddWithValue($"@{prop.Name}", prop.GetValue(parameters) ?? DBNull.Value);
+                    AddParameter(cmd, prop.Name, prop.GetValue(parameters));
                 }
             }
             using var da = new SqlDataAdapter(cmd);
@@ -52,6 +52,41 @@ namespace SQLUnitTest.Repositories
             await conn.OpenAsync();
             da.Fill(dt);
             return dt;
+        }
+
+        private static void AddParameter(SqlCommand cmd, string name, object? value)
+        {
+            var param = new SqlParameter($"@{name}", value ?? DBNull.Value)
+            {
+                SqlDbType = GetSqlDbType(value)
+            };
+            cmd.Parameters.Add(param);
+        }
+
+        private static SqlDbType GetSqlDbType(object? value)
+        {
+            if (value == null)
+            {
+                return SqlDbType.Variant;
+            }
+
+            var type = Nullable.GetUnderlyingType(value.GetType()) ?? value.GetType();
+
+            return Type.GetTypeCode(type) switch
+            {
+                TypeCode.Boolean => SqlDbType.Bit,
+                TypeCode.Byte => SqlDbType.TinyInt,
+                TypeCode.Int16 => SqlDbType.SmallInt,
+                TypeCode.Int32 => SqlDbType.Int,
+                TypeCode.Int64 => SqlDbType.BigInt,
+                TypeCode.Single => SqlDbType.Real,
+                TypeCode.Double => SqlDbType.Float,
+                TypeCode.Decimal => SqlDbType.Decimal,
+                TypeCode.DateTime => SqlDbType.DateTime,
+                TypeCode.String => SqlDbType.NVarChar,
+                _ => type == typeof(Guid) ? SqlDbType.UniqueIdentifier :
+                     type == typeof(byte[]) ? SqlDbType.VarBinary : SqlDbType.Variant
+            };
         }
     }
 }

--- a/Repositories/AdoDbRepository.cs
+++ b/Repositories/AdoDbRepository.cs
@@ -23,7 +23,14 @@ namespace SQLUnitTest.Repositories
             var ds = new DataSet();
             using var conn = new SqlConnection(_connections[connectionName]);
             using var cmd = new SqlCommand(storedProcedure, conn) { CommandType = CommandType.StoredProcedure };
-            if (parameters != null)
+            if (parameters is IDictionary<string, object> dict)
+            {
+                foreach (var kvp in dict)
+                {
+                    cmd.Parameters.AddWithValue($"@{kvp.Key}", kvp.Value ?? DBNull.Value);
+                }
+            }
+            else if (parameters != null)
             {
                 foreach (var prop in parameters.GetType().GetProperties())
                 {

--- a/SQLUnitTest.Tests/Services/BDDTestRunnerTests.cs
+++ b/SQLUnitTest.Tests/Services/BDDTestRunnerTests.cs
@@ -14,12 +14,12 @@ namespace SQLUnitTest.Tests.Services
         {
             public bool CanHandleCalled { get; private set; }
             public bool ExecuteCalled { get; private set; }
-            public bool CanHandle(TestCase testCase)
+            public bool CanHandle(BaseTestCase testCase)
             {
                 CanHandleCalled = true;
                 return testCase is ExecutionTestCase;
             }
-            public Task<TestResult> ExecuteAsync(TestCase testCase)
+            public Task<TestResult> ExecuteAsync(BaseTestCase testCase)
             {
                 ExecuteCalled = true;
                 return Task.FromResult(new TestResult { Passed = true, Report = "ok" });

--- a/Services/BDDTestRunner.cs
+++ b/Services/BDDTestRunner.cs
@@ -19,7 +19,7 @@ namespace SQLUnitTest.Services
             _handlers = handlers;
         }
 
-        public async Task<TestResult> RunTestAsync(TestCase testCase)
+        public async Task<TestResult> RunTestAsync(BaseTestCase testCase)
         {
             var handler = _handlers.FirstOrDefault(h => h.CanHandle(testCase));
             if (handler == null)

--- a/Services/Handlers/ITestCaseHandler.cs
+++ b/Services/Handlers/ITestCaseHandler.cs
@@ -5,18 +5,18 @@ using SQLUnitTest.Services.Models;
 namespace SQLUnitTest.Services.Handlers
 {
     /// <summary>
-    /// Executes a <see cref="TestCase"/>.
+    /// Executes a <see cref="BaseTestCase"/>.
     /// </summary>
     public interface ITestCaseHandler
     {
         /// <summary>
         /// Determines if this handler can process the given test case.
         /// </summary>
-        bool CanHandle(TestCase testCase);
+        bool CanHandle(BaseTestCase testCase);
 
         /// <summary>
         /// Executes the test case and returns the result.
         /// </summary>
-        Task<TestResult> ExecuteAsync(TestCase testCase);
+        Task<TestResult> ExecuteAsync(BaseTestCase testCase);
     }
 }

--- a/Services/Handlers/TestCaseHandler.cs
+++ b/Services/Handlers/TestCaseHandler.cs
@@ -7,12 +7,12 @@ namespace SQLUnitTest.Services.Handlers
     /// <summary>
     /// Base helper for implementing <see cref="ITestCaseHandler"/> for a specific test type.
     /// </summary>
-    /// <typeparam name="T">Type of <see cref="TestCase"/> handled.</typeparam>
-    public abstract class TestCaseHandler<T> : ITestCaseHandler where T : TestCase
+    /// <typeparam name="T">Type of <see cref="BaseTestCase"/> handled.</typeparam>
+    public abstract class TestCaseHandler<T> : ITestCaseHandler where T : BaseTestCase
     {
-        public bool CanHandle(TestCase testCase) => testCase is T;
+        public bool CanHandle(BaseTestCase testCase) => testCase is T;
 
-        public Task<TestResult> ExecuteAsync(TestCase testCase)
+        public Task<TestResult> ExecuteAsync(BaseTestCase testCase)
         {
             return ExecuteAsync((T)testCase);
         }

--- a/Services/ITestRunner.cs
+++ b/Services/ITestRunner.cs
@@ -5,10 +5,10 @@ using SQLUnitTest.Services.Models;
 namespace SQLUnitTest.Services
 {
     /// <summary>
-    /// Executes <see cref="TestCase"/> instances.
+    /// Executes <see cref="BaseTestCase"/> instances.
     /// </summary>
     public interface ITestRunner
     {
-        Task<TestResult> RunTestAsync(TestCase testCase);
+        Task<TestResult> RunTestAsync(BaseTestCase testCase);
     }
 }


### PR DESCRIPTION
## Summary
- detach `BaseTestCase` from `TestCase`
- update handler interfaces and BDD runner to accept `BaseTestCase`
- fix markdown reporter to use `TestName` fallback
- update related unit tests

## Testing
- `dotnet build SQLUnitTest.sln --no-restore`
- `dotnet test SQLUnitTest.sln --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_6869f1180da083208dcd1164dcc3b161