### PR TITLE
Enable LocalDB installation in CI

### DIFF
--- a/.github/workflows/MasterPipeline.yml
+++ b/.github/workflows/MasterPipeline.yml
@@ -6,7 +6,7 @@ on:
 
 jobs: 
   sonarcloud-analysis:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     env:
       Solution_Name: Dotnet_Base_Backend.sln
@@ -20,10 +20,28 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install .NET 
+      - name: Install .NET
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
+
+      - name: Download SQL Server LocalDB Installer
+        run: |
+          Invoke-WebRequest `
+            -Uri "https://go.microsoft.com/fwlink/?linkid=2239263" `
+            -OutFile "$env:TEMP\SqlLocalDB.msi"
+        shell: pwsh
+
+      - name: Install LocalDB silently
+        run: |
+          Start-Process "msiexec.exe" `
+            -ArgumentList "/i `"$env:TEMP\SqlLocalDB.msi`" /quiet /norestart" `
+            -Wait
+        shell: pwsh
+
+      - name: Verify installation
+        run: sqllocaldb info
+        shell: pwsh
 
       - name: install dotnet-coverage
         run: dotnet tool install --global dotnet-coverage

--- a/.github/workflows/TestAndDeploy.yml
+++ b/.github/workflows/TestAndDeploy.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         configuration: [ "Debug", "Release" ]
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     env:
       Solution_Name: Dotnet_Base_Backend.sln
@@ -24,10 +24,28 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install .NET 
+      - name: Install .NET
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
+
+      - name: Download SQL Server LocalDB Installer
+        run: |
+          Invoke-WebRequest `
+            -Uri "https://go.microsoft.com/fwlink/?linkid=2239263" `
+            -OutFile "$env:TEMP\SqlLocalDB.msi"
+        shell: pwsh
+
+      - name: Install LocalDB silently
+        run: |
+          Start-Process "msiexec.exe" `
+            -ArgumentList "/i `"$env:TEMP\SqlLocalDB.msi`" /quiet /norestart" `
+            -Wait
+        shell: pwsh
+
+      - name: Verify installation
+        run: sqllocaldb info
+        shell: pwsh
 
       - name: Execute unit test
         run: dotnet test

--- a/Models/Mocking/MockQuery.cs
+++ b/Models/Mocking/MockQuery.cs
@@ -14,5 +14,10 @@ namespace SQLUnitTest.Models.Mocking
         /// SQL statement to execute.
         /// </summary>
         public string Query { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Type of precondition to execute. Defaults to <see cref="PreConditionType.Query"/>.
+        /// </summary>
+        public PreConditionType Type { get; set; } = PreConditionType.Query;
     }
 }

--- a/Models/Mocking/PreConditionType.cs
+++ b/Models/Mocking/PreConditionType.cs
@@ -1,0 +1,30 @@
+namespace SQLUnitTest.Models.Mocking
+{
+    /// <summary>
+    /// Supported types of preconditions.
+    /// </summary>
+    public enum PreConditionType
+    {
+        /// <summary>
+        /// Raw SQL query string.
+        /// </summary>
+        Query,
+        /// <summary>
+        /// Stored procedure name.
+        /// </summary>
+        StoredProcedure,
+        /// <summary>
+        /// Path to a JSON file containing additional preconditions.
+        /// </summary>
+        JsonFile,
+        /// <summary>
+        /// Path to a .sql file whose contents should be executed.
+        /// </summary>
+        SqlFile,
+        /// <summary>
+        /// Ensures LocalDB is installed.
+        /// </summary>
+        InstallLocalDb
+    }
+}
+

--- a/SQLUnitTest.Tests/Integration/LocalDbIntegrationTests.cs
+++ b/SQLUnitTest.Tests/Integration/LocalDbIntegrationTests.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using SQLUnitTest.Models;
+using SQLUnitTest.Models.Mocking;
+using SQLUnitTest.Reporting;
+using System.Runtime.InteropServices;
+using SQLUnitTest.Services;
+using SQLUnitTest.Services.Handlers;
+using SQLUnitTest.Repositories;
+using Xunit;
+
+namespace SQLUnitTest.Tests.Integration
+{
+    public class LocalDbIntegrationTests
+    {
+        [Fact]
+        public async Task RunnerExecutesPreConditionsAndStoredProcedure()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+            var dbFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".mdf");
+            var connStr = $"Data Source=(localdb)\\MSSQLLocalDB;Integrated Security=True;AttachDbFilename={dbFile};";
+            var connections = new Dictionary<string, string> { { "Default", connStr } };
+
+            var services = new ServiceCollection();
+            var repo = new AdoDbRepository(connections);
+            services.AddSingleton<IDbRepository>(repo);
+            services.AddSingleton<IMarkdownReporter, MarkdownReporter>();
+            services.AddTransient<ITestCaseHandler, ExecutionTestCaseHandler>();
+            services.AddTransient<ITestRunner, BDDTestRunner>();
+            var provider = services.BuildServiceProvider();
+
+            var runner = provider.GetRequiredService<ITestRunner>();
+
+            var sqlFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".sql");
+            await File.WriteAllTextAsync(sqlFile, "CREATE PROCEDURE sp_seed AS INSERT INTO Users(Name) VALUES ('Charlie');");
+
+            var jsonFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".json");
+            var jsonContent = "{ \"preConditions\" : [ { \"connection\" : \"Default\", \"query\" : \"INSERT INTO Users(Name) VALUES ('Alice'), ('Bob');\", \"type\" : \"Query\" } ] }";
+            await File.WriteAllTextAsync(jsonFile, jsonContent);
+
+            var test = new TestCase
+            {
+                Mock = new MockBlock
+                {
+                    PreConditions = new List<MockQuery>
+                    {
+                        new MockQuery{ Type = PreConditionType.InstallLocalDb },
+                        new MockQuery{ Connection="Default", Query="CREATE TABLE Users(Id INT PRIMARY KEY IDENTITY, Name NVARCHAR(50));", Type=PreConditionType.Query },
+                        new MockQuery{ Connection="Default", Query=sqlFile, Type=PreConditionType.SqlFile },
+                        new MockQuery{ Connection="Default", Query="sp_seed", Type=PreConditionType.StoredProcedure },
+                        new MockQuery{ Connection="Default", Query=jsonFile, Type=PreConditionType.JsonFile }
+                    }
+                },
+                Should = new List<BaseTestCase>
+                {
+                    new ExecutionTestCase { StoredProcedure = "SELECT COUNT(*) AS Total FROM Users;" }
+                }
+            };
+
+            var result = await runner.RunTestAsync(test);
+
+            var countTable = await repo.QueryAsync("SELECT COUNT(*) AS Total FROM Users;", "Default");
+            countTable.Rows[0][0].Should().Be(3);
+            result.Passed.Should().BeTrue();
+        }
+    }
+}

--- a/SQLUnitTest.Tests/Services/BDDTestRunnerTests.cs
+++ b/SQLUnitTest.Tests/Services/BDDTestRunnerTests.cs
@@ -7,6 +7,9 @@ using SQLUnitTest.Services.Handlers;
 using SQLUnitTest.Services.Models;
 using System.Text.Json;
 using Xunit;
+using SQLUnitTest.Repositories;
+using System.Data;
+using SQLUnitTest.Models.Mocking;
 
 namespace SQLUnitTest.Tests.Services
 {
@@ -34,11 +37,30 @@ namespace SQLUnitTest.Tests.Services
             }
         }
 
+        private class FakeRepository : IDbRepository
+        {
+            public List<string> Queries { get; } = new();
+            public List<string> StoredProcedures { get; } = new();
+
+            public Task<DataSet> ExecuteStoredProcedureAsync(string storedProcedure, object? parameters, string connectionName)
+            {
+                StoredProcedures.Add(storedProcedure);
+                return Task.FromResult(new DataSet());
+            }
+
+            public Task<DataTable> QueryAsync(string query, string connectionName)
+            {
+                Queries.Add(query);
+                return Task.FromResult(new DataTable());
+            }
+        }
+
         [Fact]
         public async Task GivenExecutionTestCaseWhenRunTestAsyncShouldInvokeHandlerThenReturnResult()
         {
             var handler = new FakeHandler();
-            var runner = new BDDTestRunner(new[] { handler });
+            var repo = new FakeRepository();
+            var runner = new BDDTestRunner(new[] { handler }, repo);
             var testCase = new TestCase
             {
                 Should =
@@ -56,10 +78,34 @@ namespace SQLUnitTest.Tests.Services
         }
 
         [Fact]
+        public async Task GivenStoredProcedurePreConditionWhenRunTestAsyncExecutesStoredProcedure()
+        {
+            var handler = new FakeHandler();
+            var repo = new FakeRepository();
+            var runner = new BDDTestRunner(new[] { handler }, repo);
+            var testCase = new TestCase
+            {
+                Mock = new MockBlock
+                {
+                    PreConditions = new List<MockQuery>
+                    {
+                        new MockQuery { Connection = "MainDb", Query = "sp_seed", Type = PreConditionType.StoredProcedure }
+                    }
+                },
+                Should = { new ExecutionTestCase { StoredProcedure = "sp" } }
+            };
+
+            await runner.RunTestAsync(testCase);
+
+            repo.StoredProcedures.Should().Contain("sp_seed");
+        }
+
+        [Fact]
         public async Task GivenJsonWhenRunTestAsyncShouldDeserializeThenExecute()
         {
             var handler = new FakeHandler();
-            var runner = new BDDTestRunner(new[] { handler });
+            var repo = new FakeRepository();
+            var runner = new BDDTestRunner(new[] { handler }, repo);
             var json = "{\"should\":[{\"type\":\"ExecutionTestCase\",\"storedProcedure\":\"sp\"}]}";
 
             var result = await runner.RunTestAsync(json);
@@ -74,7 +120,8 @@ namespace SQLUnitTest.Tests.Services
         public async Task GivenComplexJsonWhenRunTestAsyncShouldMaterializeStoredProcedureCompareCase()
         {
             var handler = new FakeHandler();
-            var runner = new BDDTestRunner(new[] { handler });
+            var repo = new FakeRepository();
+            var runner = new BDDTestRunner(new[] { handler }, repo);
             var json = @"{
   ""describe"": ""User report comparison"",
   ""context"": ""Filtering users by region"",
@@ -115,7 +162,8 @@ namespace SQLUnitTest.Tests.Services
         public async Task GivenJsonWithMultipleShouldWhenRunTestAsyncShouldDeserializeAll()
         {
             var handler = new FakeHandler();
-            var runner = new BDDTestRunner(new[] { handler });
+            var repo = new FakeRepository();
+            var runner = new BDDTestRunner(new[] { handler }, repo);
             var json = @"{
   ""describe"": ""User report comparison"",
   ""context"": ""Filtering users by region"",
@@ -160,6 +208,7 @@ namespace SQLUnitTest.Tests.Services
             var pre = deserialized.Mock.PreConditions![0];
             pre.Connection.Should().Be("MainDb");
             pre.Query.Should().Be("INSERT INTO Users ...");
+            pre.Type.Should().Be(PreConditionType.Query);
             deserialized.Should.Should().HaveCount(2);
 
             var result = await runner.RunTestAsync(json);
@@ -175,6 +224,7 @@ namespace SQLUnitTest.Tests.Services
             c2.ExpectedStoredProcedure.Should().Be("sp_Expected2");
             result.Report.Should().Be("ok\nok");
             result.Passed.Should().BeTrue();
+            repo.Queries.Should().ContainSingle(q => q == "INSERT INTO Users ...");
         }
     }
 }

--- a/Services/BDDTestRunner.cs
+++ b/Services/BDDTestRunner.cs
@@ -1,11 +1,15 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using SQLUnitTest.Models;
+using SQLUnitTest.Models.Mocking;
 using SQLUnitTest.Services.Handlers;
+using SQLUnitTest.Repositories;
 using SQLUnitTest.Services.Models;
+using SQLUnitTest.Utilities;
 
 namespace SQLUnitTest.Services
 {
@@ -15,10 +19,12 @@ namespace SQLUnitTest.Services
     public class BDDTestRunner : ITestRunner
     {
         private readonly IEnumerable<ITestCaseHandler> _handlers;
+        private readonly IDbRepository _repository;
 
-        public BDDTestRunner(IEnumerable<ITestCaseHandler> handlers)
+        public BDDTestRunner(IEnumerable<ITestCaseHandler> handlers, IDbRepository repository)
         {
             _handlers = handlers;
+            _repository = repository;
         }
 
         private async Task<TestResult> RunBaseTestAsync(BaseTestCase testCase)
@@ -32,8 +38,49 @@ namespace SQLUnitTest.Services
             return await handler.ExecuteAsync(testCase);
         }
 
+        private async Task RunPreConditionAsync(MockQuery pre)
+        {
+            switch (pre.Type)
+            {
+                case PreConditionType.Query:
+                    await _repository.QueryAsync(pre.Query, pre.Connection);
+                    break;
+                case PreConditionType.StoredProcedure:
+                    await _repository.ExecuteStoredProcedureAsync(pre.Query, null, pre.Connection);
+                    break;
+                case PreConditionType.SqlFile:
+                    var sql = File.ReadAllText(pre.Query);
+                    await _repository.QueryAsync(sql, pre.Connection);
+                    break;
+                case PreConditionType.JsonFile:
+                    var json = File.ReadAllText(pre.Query);
+                    var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                    options.Converters.Add(new BaseTestCaseJsonConverter());
+                    var fromFile = JsonSerializer.Deserialize<TestCase>(json, options);
+                    if (fromFile?.Mock?.PreConditions != null)
+                    {
+                        foreach (var nested in fromFile.Mock.PreConditions)
+                        {
+                            await RunPreConditionAsync(nested);
+                        }
+                    }
+                    break;
+                case PreConditionType.InstallLocalDb:
+                    await LocalDbInstaller.InstallAsync();
+                    break;
+            }
+        }
+
         public async Task<TestResult> RunTestAsync(TestCase testCase)
         {
+            if (testCase.Mock?.PreConditions != null)
+            {
+                foreach (var pre in testCase.Mock.PreConditions)
+                {
+                    await RunPreConditionAsync(pre);
+                }
+            }
+
             var sb = new StringBuilder();
             var passed = true;
             foreach (var should in testCase.Should)

--- a/Utilities/LocalDbInstaller.cs
+++ b/Utilities/LocalDbInstaller.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace SQLUnitTest.Utilities
+{
+    /// <summary>
+    /// Helper to install SQL Server LocalDB if not already present.
+    /// </summary>
+    public static class LocalDbInstaller
+    {
+        private const string DownloadUrl = "https://go.microsoft.com/fwlink/?linkid=2239263";
+
+        public static async Task InstallAsync()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            if (IsInstalled())
+            {
+                return;
+            }
+
+            var tempPath = Path.Combine(Path.GetTempPath(), "SqlLocalDB.msi");
+            if (!File.Exists(tempPath))
+            {
+                using var http = new HttpClient();
+                var data = await http.GetByteArrayAsync(DownloadUrl);
+                File.WriteAllBytes(tempPath, data);
+            }
+
+            var process = Process.Start(new ProcessStartInfo("msiexec.exe", $"/i \"{tempPath}\" /quiet /norestart") { UseShellExecute = false });
+            process?.WaitForExit();
+        }
+
+        private static bool IsInstalled()
+        {
+            try
+            {
+                var proc = Process.Start(new ProcessStartInfo("sqllocaldb", "info") { RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false });
+                proc.WaitForExit();
+                return proc.ExitCode == 0;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- install SQL Server LocalDB using a PowerShell script
- keep Windows runners to support LocalDB
- skip LocalDB integration test when running on non-Windows systems
- add new precondition types including LocalDB installation

## Testing
- `dotnet build SQLUnitTest.Tests/SQLUnitTest.Tests.csproj --configuration Debug`
- `dotnet test SQLUnitTest.Tests/SQLUnitTest.Tests.csproj --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_686b40106bcc832086070791e1c1a20a